### PR TITLE
Fixed URLs in .md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,19 +8,19 @@ bit easier.
 
 How to contribute
 -----------------
-The preferred way to contribute to Python-EBM is to fork the 
-[main repository](https://github.com/ucl-mig/Python-EBM) on
+The preferred way to contribute to ebm is to fork the 
+[main repository](https://github.com/ucl-mig/ebm) on
 GitHub:
 
-1. Fork the [project repository](https://github.com/ucl-mig/Python-EBM):
+1. Fork the [project repository](https://github.com/ucl-mig/ebm):
    click on the 'Fork' button at the top right of the page. This creates
    a copy of the code under your account on the GitHub server.
 
 2. Clone this copy to your local disk:
 
-          $ git clone https://github.com/YourGitHubLogin/Python-EBM.git
+          $ git clone https://github.com/YourGitHubLogin/ebm.git
           [enter username and password as requested]
-          $ cd Python-EBM
+          $ cd ebm
 
 3. Create a branch to hold your changes:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Event-Based Model (EBM) is a simple, robust model for the estimation of the 
 Important Links
 ===============
 
-- [Issue tracker](https://github.com/ucl-mig/Python-EBM/issues)
+- [Issue tracker](https://github.com/ucl-mig/ebm/issues)
 
 EBM Papers
 ----------
@@ -27,4 +27,4 @@ The code depends heavily on NumPy, uses SciPy to calculate some stats and do som
 
 Contributing
 ============
-Please read the [CONTRIBUTING.md](https://github.com/ucl-mig/Python-EBM/blob/master/CONTRIBUTING.md) file before making any contributions.
+Please read the [CONTRIBUTING.md](https://github.com/ucl-mig/ebm/blob/master/CONTRIBUTING.md) file before making any contributions.


### PR DESCRIPTION
Self-explanatory. The URLs were a relic from the old Python-EBM repo.